### PR TITLE
Update remove-knowledgebase.ps1

### DIFF
--- a/ps/remove-knowledgebase.ps1
+++ b/ps/remove-knowledgebase.ps1
@@ -213,7 +213,7 @@ function Remove-KnowledgeBase() {
 		return
 	}
 
-	$command = "Remove-Item -path $($folder) -recurse -force"
+	$command = "Remove-Item -path '$($folder)' -recurse -force"
 	if (Invoke-Command-With-Permission -message "Do you want to delete KB folder at $($folder)?" -command $command) {
 		Invoke-Expression $command
 	}


### PR DESCRIPTION
It's normal for Knowledge bases to have space character in there directory name which will raise an error using remove-item command